### PR TITLE
CandyJs Detect Control + Click

### DIFF
--- a/assets/js/candy.js
+++ b/assets/js/candy.js
@@ -264,6 +264,7 @@ const Candy = {
   loader: function(element,arr,callback){
     this.loader.elements = arr;
     $(document).on('click',element,function(e){
+      if(e.ctrlKey || e.metaKey) return;
       var url_now = window.location.href;
       var url_go = $(this).attr('href');
       var target = $(this).attr('target');


### PR DESCRIPTION
When user click on loader links with Control(Ctrl for mac Command) key it will open in new tab instead load data with ajax.